### PR TITLE
Get RGA working with Direct3D sources even if no AMD hardware is present.

### DIFF
--- a/RadeonGPUAnalyzerBackend/src/beBackend.cpp
+++ b/RadeonGPUAnalyzerBackend/src/beBackend.cpp
@@ -80,7 +80,7 @@ beKA::beStatus Backend::Initialize(BuiltProgramKind ProgramKind, LoggingCallBack
     }
 
 
-    if (m_beOpenCL == NULL)
+    if (m_beOpenCL == NULL && ProgramKind == BuiltProgramKind_OpenCL)
     {
         m_beOpenCL = new beProgramBuilderOpenCL();
     }

--- a/RadeonGPUAnalyzerBackend/src/beProgramBuilderDX.cpp
+++ b/RadeonGPUAnalyzerBackend/src/beProgramBuilderDX.cpp
@@ -287,6 +287,16 @@ beKA::beStatus beProgramBuilderDX::Initialize(const string& msD3DCompilerModuleT
             }
         }
 
+        // If this is empty then odds are you are not using AMD hardware.
+        if(m_DXDeviceTable.empty())
+        {
+            m_DXDeviceTable.reserve(gs_cardInfoSize);
+            for(size_t i = 0ULL; i < gs_cardInfoSize; ++i)
+            {
+                m_DXDeviceTable.push_back(gs_cardInfo[i]);
+            }
+        }
+
         std::sort(m_DXDeviceTable.begin(), m_DXDeviceTable.end(), beUtils::GfxCardInfoSortPredicate);
     }
 


### PR DESCRIPTION
Also do not initialize OpenCL unless an OpenCL source is meant to be used.