### PR TITLE
Get RGA working with HLSL input on non-AMD hardware. 

### DIFF
--- a/RadeonGPUAnalyzerBackend/src/beBackend.cpp
+++ b/RadeonGPUAnalyzerBackend/src/beBackend.cpp
@@ -80,7 +80,7 @@ beKA::beStatus Backend::Initialize(BuiltProgramKind ProgramKind, LoggingCallBack
     }
 
 
-    if (m_beOpenCL == NULL)
+    if (m_beOpenCL == NULL && ProgramKind == BuiltProgramKind_OpenCL)
     {
         m_beOpenCL = new beProgramBuilderOpenCL();
     }

--- a/RadeonGPUAnalyzerBackend/src/beProgramBuilderDX.cpp
+++ b/RadeonGPUAnalyzerBackend/src/beProgramBuilderDX.cpp
@@ -287,6 +287,12 @@ beKA::beStatus beProgramBuilderDX::Initialize(const string& msD3DCompilerModuleT
             }
         }
 
+        // If this is empty then odds are you are not using AMD hardware.
+        if(m_DXDeviceTable.empty())
+        {
+            AMDTDeviceInfoUtils::Instance()->GetAllCards(m_DXDeviceTable);
+        }
+
         std::sort(m_DXDeviceTable.begin(), m_DXDeviceTable.end(), beUtils::GfxCardInfoSortPredicate);
     }
 


### PR DESCRIPTION
This pull request removes the need for the OpenCL backend when processing HLSL input. The OpenCL backend tries to create OpenCL contexts with the CL_CONTEXT_OFFLINE_DEVICES_AMD extension which is not supported by Nvidia (and perhaps none of the other IHVs), and it also does vendor string checks that would never work in non-AMD devices as seen in https://github.com/GPUOpen-Tools/RGA/blob/master/RadeonGPUAnalyzerBackend/src/beProgramBuilderOpenCL.cpp#L354

The OpenCL backend was only needed when processing HLSL input to eventually fill up beProgramBuilderDX::m_DXDeviceTable which is now done via the AMDTDeviceInfoUtils::GetAllCards() method which is part of pull request https://github.com/GPUOpen-Tools/common-src-DeviceInfo/pull/1