### PR TITLE
Fix responsiveness of RGA GUI disassembly view

### DIFF
--- a/RadeonGPUAnalyzerGUI/Include/Qt/rgIsaDisassemblyView.h
+++ b/RadeonGPUAnalyzerGUI/Include/Qt/rgIsaDisassemblyView.h
@@ -233,9 +233,6 @@ protected:
     // Set the cursor to pointing hand cursor for various widgets.
     void SetCursor();
 
-    // Set the border stylesheet.
-    virtual void SetBorderStylesheet() = 0;
-
     // Set the current target GPU to display disassembly for.
     void SetTargetGpu(const std::string& targetGpu);
 

--- a/RadeonGPUAnalyzerGUI/Include/Qt/rgIsaDisassemblyViewOpenCL.h
+++ b/RadeonGPUAnalyzerGUI/Include/Qt/rgIsaDisassemblyViewOpenCL.h
@@ -16,9 +16,6 @@ public:
     virtual bool PopulateBuildOutput(const std::shared_ptr<rgProjectClone> pProjectClone, const rgBuildOutputsMap& buildOutputs) override;
 
 protected:
-    // Set the border stylesheet.
-    virtual void SetBorderStylesheet() override;
-
     // Populate the disassembly view with the given CLI build output.
     bool PopulateDisassemblyView(const std::vector<rgSourceFileInfo>& sourceFiles, const rgBuildOutputsMap& buildOutput);
 };

--- a/RadeonGPUAnalyzerGUI/Include/Qt/rgIsaDisassemblyViewVulkan.h
+++ b/RadeonGPUAnalyzerGUI/Include/Qt/rgIsaDisassemblyViewVulkan.h
@@ -14,8 +14,4 @@ class rgIsaDisassemblyViewVulkan : public rgIsaDisassemblyViewGraphics
 public:
     rgIsaDisassemblyViewVulkan(QWidget* pParent);
     virtual ~rgIsaDisassemblyViewVulkan() = default;
-
-protected:
-    // Set the border stylesheet.
-    virtual void SetBorderStylesheet() override;
 };

--- a/RadeonGPUAnalyzerGUI/Include/rgStringConstants.h
+++ b/RadeonGPUAnalyzerGUI/Include/rgStringConstants.h
@@ -526,11 +526,6 @@ static const char* STR_MAIN_WINDOW_STYLESHEET_FILE        = "rgMainWindowStyle.q
 static const char* STR_MAIN_WINDOW_STYLESHEET_FILE_OPENCL = "OpenCL/rgMainWindowStyleOpenCL.qss";
 static const char* STR_MAIN_WINDOW_STYLESHEET_FILE_VULKAN = "Vulkan/rgMainWindowStyleVulkan.qss";
 
-// Disassembly view frame border color.
-static const char* STR_DISASSEMBLY_FRAME_BORDER_RED_STYLESHEET = "QFrame#frame {border: 1px solid rgb(224,30,55)}";
-static const char* STR_DISASSEMBLY_FRAME_BORDER_GREEN_STYLESHEET = "QFrame#frame {border: 1px solid rgb(18, 152, 0)}";
-static const char* STR_DISASSEMBLY_FRAME_BORDER_BLACK_STYLESHEET = "QFrame#frame {border: 1px solid black}";
-
 // The "current" property of file menu items.
 static const char* STR_FILE_MENU_PROPERTY_CURRENT = "current";
 

--- a/RadeonGPUAnalyzerGUI/Src/rgIsaDisassemblyView.cpp
+++ b/RadeonGPUAnalyzerGUI/Src/rgIsaDisassemblyView.cpp
@@ -14,6 +14,7 @@
 // Qt.
 #include <QCheckBox>
 #include <QListWidgetItem>
+#include <QAction>
 
 // Infra.
 #include <QtCommon/CustomWidgets/ArrowIconWidget.h>
@@ -1110,27 +1111,18 @@ void rgIsaDisassemblyView::HandleDisassemblyTabViewClicked()
     // Emit a signal to indicate that disassembly view was clicked.
     emit DisassemblyViewClicked();
 
-    // Highlight the frame in the correct API color (give it focus).
-    SetBorderStylesheet();
-
     // Remove the button focus in the file menu.
     emit RemoveFileMenuButtonFocus();
 }
 
 void rgIsaDisassemblyView::HandleDisassemblyTabViewLostFocus()
 {
-    // Highlight the frame in black.
-    ui.frame->setStyleSheet(STR_DISASSEMBLY_FRAME_BORDER_BLACK_STYLESHEET);
-
     // Remove the button focus in the file menu.
     emit RemoveFileMenuButtonFocus();
 }
 
 void rgIsaDisassemblyView::HandleResourceUsageViewFocusOutEvent()
 {
-    // Highlight the frame in black.
-    ui.frame->setStyleSheet(STR_DISASSEMBLY_FRAME_BORDER_BLACK_STYLESHEET);
-
     // Remove the button focus in the file menu.
     emit RemoveFileMenuButtonFocus();
 }
@@ -1139,9 +1131,6 @@ void rgIsaDisassemblyView::HandleTitlebarClickedEvent(QMouseEvent* pEvent)
 {
     // Emit a signal to indicate that disassembly view was clicked.
     emit DisassemblyViewClicked();
-
-    // Highlight the frame in the correct API color (give it focus).
-    SetBorderStylesheet();
 
     // Remove the button focus in the file menu.
     emit RemoveFileMenuButtonFocus();
@@ -1152,22 +1141,16 @@ void rgIsaDisassemblyView::HandleListWidgetFocusInEvent()
     // Emit a signal to indicate that disassembly view was clicked.
     emit DisassemblyViewClicked();
 
-    // Highlight the frame in the correct API color (give it focus).
-    SetBorderStylesheet();
-
     // Remove the button focus in the file menu.
     emit RemoveFileMenuButtonFocus();
 }
 
 void rgIsaDisassemblyView::HandleListWidgetFocusOutEvent()
 {
-    ui.frame->setStyleSheet(STR_DISASSEMBLY_FRAME_BORDER_BLACK_STYLESHEET);
 }
 
 void rgIsaDisassemblyView::HandleFocusOutEvent()
 {
-    ui.frame->setStyleSheet(STR_DISASSEMBLY_FRAME_BORDER_BLACK_STYLESHEET);
-
     // Remove the button focus in the file menu.
     emit RemoveFileMenuButtonFocus();
 }

--- a/RadeonGPUAnalyzerGUI/Src/rgIsaDisassemblyViewOpenCL.cpp
+++ b/RadeonGPUAnalyzerGUI/Src/rgIsaDisassemblyViewOpenCL.cpp
@@ -27,11 +27,6 @@ bool rgIsaDisassemblyViewOpenCL::PopulateBuildOutput(const std::shared_ptr<rgPro
     return ret;
 }
 
-void rgIsaDisassemblyViewOpenCL::SetBorderStylesheet()
-{
-    ui.frame->setStyleSheet(STR_DISASSEMBLY_FRAME_BORDER_GREEN_STYLESHEET);
-}
-
 bool rgIsaDisassemblyViewOpenCL::PopulateDisassemblyView(const std::vector<rgSourceFileInfo>& sourceFiles, const rgBuildOutputsMap& buildOutput)
 {
     bool isProblemFound = false;

--- a/RadeonGPUAnalyzerGUI/Src/rgIsaDisassemblyViewVulkan.cpp
+++ b/RadeonGPUAnalyzerGUI/Src/rgIsaDisassemblyViewVulkan.cpp
@@ -8,8 +8,3 @@ rgIsaDisassemblyViewVulkan::rgIsaDisassemblyViewVulkan(QWidget* pParent)
     : rgIsaDisassemblyViewGraphics(pParent)
 {
 }
-
-void rgIsaDisassemblyViewVulkan::SetBorderStylesheet()
-{
-    ui.frame->setStyleSheet(STR_DISASSEMBLY_FRAME_BORDER_RED_STYLESHEET);
-}

--- a/RadeonGPUAnalyzerGUI/Src/rgSettingsButtonsView.cpp
+++ b/RadeonGPUAnalyzerGUI/Src/rgSettingsButtonsView.cpp
@@ -8,6 +8,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QWidget>
+#include <QAction>
 
 // Infra.
 #include <QtCommon/CustomWidgets/ArrowIconWidget.h>


### PR DESCRIPTION
The GUI becomes unresponsive for several seconds whenever the disassembly view
gains or loses focus due to the code unnecessarily applying a stylesheet to
the entire frame just to change border color, which seems to be a leftover
functionality, considering that the color was only affected by the API used
which is now chosen at application launch so the border color does not provide
much value. According to the Qt documentation applications should not call
setStylesheet() outside of the constructor because it's very costly and the
current code calls it on focus change.

This change fixes that by getting rid of all the code using setStylesheet()
to change the disassembly view's border.

Also, some missing header includes were added which most likely were
uncovered by compiling against Qt 5.11.2 contrarily to Qt 5.9.2 recommended
in the RGA documentation.