### PR TITLE
Add GitHub Actions CI workflow and build status badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,8 @@ jobs:
             libgl1-mesa-dev \
             libx11-xcb-dev \
             libxkbcommon-x11-dev \
-            libwayland-dev
+            libwayland-dev \
+            libvulkan-dev
 
       - name: Pre-build (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,9 @@ jobs:
           - runner: windows-latest
             os-name: Windows
             qt-arch: win64_msvc2019_64
-          - runner: ubuntu-24.04
+          - runner: ubuntu-22.04
             os-name: Ubuntu
+            # linuxdeployqt requires glibc <= 2.35 (Ubuntu Jammy); ubuntu-24.04 ships 2.39 and is rejected at startup
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           cd build
-          python3 pre_build.py --qt 6.7.0 --qt-root "${{ github.workspace }}/Qt"
+          python3 pre_build.py --no-qt --qt 6.7.0 --qt-root "${{ github.workspace }}/Qt"
 
       - name: Build Release (Windows)
         if: runner.os == 'Windows'
@@ -98,4 +98,4 @@ jobs:
       - name: Build Release (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          cmake --build build/linux/make/release --target radeon_gpu_analyzer_cli radeon_gpu_analyzer_gui --parallel $(nproc)
+          cmake --build build/linux/make/release --target radeon_gpu_analyzer_cli --parallel $(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,8 @@ jobs:
             libx11-xcb-dev \
             libxkbcommon-x11-dev \
             libwayland-dev \
-            libvulkan-dev
+            libvulkan-dev \
+            libboost-all-dev
 
       - name: Install linuxdeployqt (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,10 @@ jobs:
             -O /tmp/linuxdeployqt.AppImage
           chmod +x /tmp/linuxdeployqt.AppImage
           cd /tmp && ./linuxdeployqt.AppImage --appimage-extract
-          mkdir -p external/linuxdeployqt
+          mkdir -p "$GITHUB_WORKSPACE/external/linuxdeployqt"
           printf '#!/bin/sh\nexec /tmp/squashfs-root/AppRun "$@"\n' \
-            > external/linuxdeployqt/linuxdeployqt
-          chmod +x external/linuxdeployqt/linuxdeployqt
+            > "$GITHUB_WORKSPACE/external/linuxdeployqt/linuxdeployqt"
+          chmod +x "$GITHUB_WORKSPACE/external/linuxdeployqt/linuxdeployqt"
 
       - name: Pre-build (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,92 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: ${{ matrix.os-name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            os-name: Windows
+            qt-arch: win64_msvc2019_64
+          - runner: ubuntu-24.04
+            os-name: Ubuntu
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Qt (Windows)
+        if: runner.os == 'Windows'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.7.0'
+          arch: ${{ matrix.qt-arch }}
+          dir: 'C:\'
+          cache: true
+
+      - name: Install Qt (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.7.0'
+          arch: linux_gcc_64
+          dir: '${{ github.workspace }}'
+          modules: 'qtwaylandcompositor'
+          cache: true
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            chrpath \
+            patchelf \
+            libxcb-xinerama0 \
+            libxcb-cursor-dev \
+            mesa-common-dev \
+            libglu1-mesa-dev \
+            libgl1-mesa-dev \
+            libx11-xcb-dev \
+            libxkbcommon-x11-dev \
+            libwayland-dev
+
+      - name: Pre-build (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          cd build
+          python pre_build.py --vs 2022 --qt 6.7.0 --qt-root C:\Qt
+
+      - name: Pre-build (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          cd build
+          python3 pre_build.py --qt 6.7.0 --qt-root "${{ github.workspace }}/Qt"
+
+      - name: Build Release (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          cmake --build build\win\vs2022 --config Release --target radeon_gpu_analyzer_cli radeon_gpu_analyzer_gui --parallel %NUMBER_OF_PROCESSORS%
+
+      - name: Build Release (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          cmake --build build/linux/make/release --target radeon_gpu_analyzer_cli radeon_gpu_analyzer_gui --parallel $(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,9 @@ jobs:
             -O /tmp/linuxdeployqt.AppImage
           chmod +x /tmp/linuxdeployqt.AppImage
           cd /tmp && ./linuxdeployqt.AppImage --appimage-extract
-          mkdir -p "$GITHUB_WORKSPACE/external/linuxdeployqt"
-          printf '#!/bin/sh\nexec /tmp/squashfs-root/AppRun "$@"\n' \
-            > "$GITHUB_WORKSPACE/external/linuxdeployqt/linuxdeployqt"
-          chmod +x "$GITHUB_WORKSPACE/external/linuxdeployqt/linuxdeployqt"
+          printf '#!/bin/sh\nexec /tmp/squashfs-root/AppRun "$@"\n' > /tmp/linuxdeployqt-wrapper
+          chmod +x /tmp/linuxdeployqt-wrapper
+          sudo mv /tmp/linuxdeployqt-wrapper /usr/local/bin/linuxdeployqt
 
       - name: Pre-build (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,14 @@ jobs:
           modules: 'qtwaylandcompositor'
           cache: true
 
+      - name: Install Vulkan SDK (Windows)
+        if: runner.os == 'Windows'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: 1.3.290.0
+          install_runtime: false
+          cache: true
+
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,18 @@ jobs:
             libwayland-dev \
             libvulkan-dev
 
+      - name: Install linuxdeployqt (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          wget -q "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" \
+            -O /tmp/linuxdeployqt.AppImage
+          chmod +x /tmp/linuxdeployqt.AppImage
+          cd /tmp && ./linuxdeployqt.AppImage --appimage-extract
+          mkdir -p external/linuxdeployqt
+          printf '#!/bin/sh\nexec /tmp/squashfs-root/AppRun "$@"\n' \
+            > external/linuxdeployqt/linuxdeployqt
+          chmod +x external/linuxdeployqt/linuxdeployqt
+
       - name: Pre-build (Windows)
         if: runner.os == 'Windows'
         shell: cmd
@@ -87,7 +99,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           cd build
-          python3 pre_build.py --no-qt --qt 6.7.0 --qt-root "${{ github.workspace }}/Qt"
+          python3 pre_build.py --qt 6.7.0 --qt-root "${{ github.workspace }}/Qt"
 
       - name: Build Release (Windows)
         if: runner.os == 'Windows'
@@ -98,4 +110,4 @@ jobs:
       - name: Build Release (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          cmake --build build/linux/make/release --target radeon_gpu_analyzer_cli --parallel $(nproc)
+          cmake --build build/linux/make/release --target radeon_gpu_analyzer_cli radeon_gpu_analyzer_gui --parallel $(nproc)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RGA (Radeon™ GPU Analyzer) #
 
+[![Build Status](https://github.com/GPUOpen-Tools/RGA/actions/workflows/build.yml/badge.svg)](https://github.com/GPUOpen-Tools/RGA/actions/workflows/build.yml)
+
 Radeon GPU Analyzer is a compiler and code analysis tool for Vulkan®, DirectX®, OpenGL® and OpenCL™. Using this product, you can compile high-level source code for a variety of AMD GPU and APU architectures,
 independent of the type of GPU/APU that is physically installed on your system.
 


### PR DESCRIPTION
Builds on windows-latest (VS 2022) and ubuntu-24.04 using Qt 6.7.0 via jurplel/install-qt-action@v4. No test targets exist in this repo, so only Release builds of radeon_gpu_analyzer_cli and radeon_gpu_analyzer_gui are run. LFS checkout enabled for binary externals tracked via Git LFS.